### PR TITLE
Andrew/start routine

### DIFF
--- a/backend-api/src/routes/index.js
+++ b/backend-api/src/routes/index.js
@@ -15,6 +15,8 @@ const testDbRoutes = require('./testDbRoute');
 const routineRoutes = require('./routineRoutes');
 //get the workout functions
 const { getAll, getById, getWorkoutById, createWorkout, updateWorkout, createHistory, getRecentHistory } = require('./workoutRoutes');
+//get routineHistoryRoutes
+const { getByIds, updateById } = require('./routineHistoryRoutes');
 
 // Health Check
 router.get('/', (req, res) => {
@@ -52,5 +54,9 @@ router.put('/workout', updateWorkout);
 router.post('/workout/finish', createHistory);
 
 router.get('/workout/history/recent', getRecentHistory);
+
+router.get('/routine/start/:userId/:routineId', getByIds); //pass route params: userid &routineId
+
+router.put('/routine/start/:id', updateById); //pass route param routineHistoryId, quewry param workoutId
 
 module.exports = router;

--- a/backend-api/src/routes/routineHistoryRoutes.js
+++ b/backend-api/src/routes/routineHistoryRoutes.js
@@ -1,0 +1,47 @@
+// src/routes/routineHistoryRoutes.js
+
+const express = require('express');
+const router = express.Router();
+const { getOrCreateRoutineHistoryByUserAndRoutine, updateRoutineHistory } = require('../services/routineHistory-service');
+
+  //Get a routine history by id and user id
+  module.exports.getByIds = async (req, res) => {
+    const userId = req.params.userId;
+    const routineId = req.params.routineId;
+
+    if (!userId || !routineId) {
+        console.log("missing user or routine");
+      return res.status(400).json({ error: 'userId and routineId are required' });
+    }
+    console.log("in get by ids for routine history");
+
+    let routineHistory = getOrCreateRoutineHistoryByUserAndRoutine(userId,routineId)
+    .then(data => {
+        console.log(data);
+      res.status(200).json(data);
+    }).catch(msg => {
+      res.status(404).json({error: msg});
+    })
+  };
+
+  module.exports.updateById = async (req, res) => {
+    const id = req.params.id;
+    const data = req.body; //array of completed exercises
+    console.log(data);
+    console.log(id);        
+
+    if (!id ) {
+        console.log("missing id");
+      return res.status(400).json({ error: 'id is required' });
+    }
+    console.log("in update by id for routine history");
+
+    let routineHistory = updateRoutineHistory(id,data)
+    .then(data => {
+        console.log(data);
+        console.log("updated routine history in db");
+      res.status(200).json(data);
+    }).catch(msg => {
+      res.status(404).json({error: msg});
+    })
+  };

--- a/backend-api/src/routes/workoutRoutes.js
+++ b/backend-api/src/routes/workoutRoutes.js
@@ -215,25 +215,38 @@ module.exports.createHistory = async (req, res) => {
   const data = req.body;
   const exercises = data.exercises;
   console.log(data);
-  console.log(data.exercises[0].sets);
 
-  for (var i = 0; i < exercises.length; i++){
-    // Create the History object
-    const historyData = {
-      historyId: new mongoose.Types.ObjectId(), // Generate a new ObjectId for historyId
-      userId: data.userId.username, // Set to userId if provided
-      exerciseName: exercises[i].name,
-      exerciseId: exercises[i].exerciseId,
-      date: new Date(),
-      info: exercises[i].sets,
-      notes: exercises[i].notes
-    };
-    console.log(historyData);
-    await historyService.createHistory(historyData);
-
-    //const result = await historyService.getRecentHistoryByUserAndExercise(data.userId.username, exercises[0].exerciseId);
-    //console.log(result);
+  if (data.exercises.length != 0) {
+    for (var i = 0; i < exercises.length; i++){
+      if (data.exercises[i].sets.length != 0){ // if not empty
+        console.log("set not empty");
+        // Create the History object
+        const historyData = {
+          historyId: new mongoose.Types.ObjectId(), // Generate a new ObjectId for historyId
+          userId: data.userId.username, // Set to userId if provided
+          exerciseName: exercises[i].name,
+          exerciseId: exercises[i].exerciseId,
+          date: new Date(),
+          info: exercises[i].sets,
+          notes: exercises[i].notes
+        };
+        console.log(historyData);
+        historyService.createHistory(historyData)
+        .then((data) => {
+          res.status(200).json(data);
+        }).catch((err) => {
+          res.status(500).json({error: err});
+        });    
+      } else {
+        console.log("empty set");
+        res.status(200);
+      }
+    }
+  } else {
+    console.log("exercises empty");
+    res.status(200);
   }
+  
 };
 
 module.exports.getRecentHistory = async (req, res) => {

--- a/backend-api/src/schemas/RoutineHistory.js
+++ b/backend-api/src/schemas/RoutineHistory.js
@@ -1,0 +1,19 @@
+//install mongoose once decided on DB
+const mongoose = require('mongoose');
+
+const routineHistorySchema = new mongoose.Schema({
+  routineHistoryId: {
+    type: mongoose.Schema.Types.ObjectId, 
+    required: true
+  },
+  routineId: { 
+    type: mongoose.Schema.Types.ObjectId, 
+    required: true 
+  },
+  userId: String,
+  completed: Array, //array is of workout ids to signify which are completed
+});
+
+const RoutineHistory = mongoose.model('RoutineHistory', routineHistorySchema);
+
+module.exports = RoutineHistory;

--- a/backend-api/src/services/routineHistory-service.js
+++ b/backend-api/src/services/routineHistory-service.js
@@ -1,0 +1,64 @@
+//history service utilizes history schema and connect to mongo
+const mongoose = require('mongoose');
+const RoutineHistory = require('../schemas/RoutineHistory');
+const { connectToDb } = require('./connectToDB');
+
+let RoutineHistoryModel;
+
+// Ensure connection to the database exists
+const ensureConnection = async () => {
+  if (!RoutineHistoryModel) {
+    await connectToDb();
+    RoutineHistoryModel = mongoose.model('RoutineHistory', RoutineHistory.schema);
+  }
+};
+
+// get history entry by userId and routineId, create if it doesn't exist
+module.exports.getOrCreateRoutineHistoryByUserAndRoutine = async function (userId, routineId) {
+    await ensureConnection();
+    return new Promise(function (resolve, reject) {
+      RoutineHistoryModel.findOne({ userId: userId, routineId: routineId })
+        .then((routineHistory) => {
+          if (routineHistory) {
+            resolve(routineHistory);
+          } else {
+            // If not found, create a new entry with all necessary fields
+            const newRoutineHistory = new RoutineHistoryModel({
+                userId,
+                routineId,
+                completed: [],
+                routineHistoryId: new mongoose.Types.ObjectId(),
+            });
+            newRoutineHistory.save()
+              .then((savedRoutineHistory) => {
+                resolve(savedRoutineHistory);
+              })
+              .catch((err) => reject('Error creating routine history record: ' + err));
+          }
+        })
+        .catch((err) => reject('Error fetching routine history record: ' + err));
+    });
+  };
+
+  //update routineHistory
+  module.exports.updateRoutineHistory = async function (routineHistoryId, completedArray) {
+    await ensureConnection();
+    console.log("in service function");
+    console.log(routineHistoryId);
+    console.log(completedArray);
+    return new Promise(function (resolve, reject) {
+      RoutineHistoryModel.findOneAndUpdate(
+        { routineHistoryId: routineHistoryId },
+        { $set: { completed: completedArray } },
+        { new: true }
+      )
+        .then((updatedRoutineHistory) => {
+          if (updatedRoutineHistory) {
+            resolve(updatedRoutineHistory);
+          } else {
+            reject('Routine history record not found');
+          }
+        })
+        .catch((err) => reject('Error updating routine history record: ' + err));
+    });
+  };

--- a/frontend-ui/src/app/browse/page.jsx
+++ b/frontend-ui/src/app/browse/page.jsx
@@ -163,6 +163,7 @@ useEffect(() => {
                         />
                     </>
                 )}
+                {/*if selected button option is routines, handle here*/}
                 {selectedOption === 'routines' && (
                     <>
                         <RoutineFilter
@@ -176,10 +177,6 @@ useEffect(() => {
                             handlePanelClick={handlePanelClick}
                         />
                     </>
-                )}
-                 {/*if selected button option is routines, handle here*/}
-                {selectedOption === 'routines' && (
-                    <p className="text-center text-red-500">Routines</p>
                 )}
                  {/*if selected button option is routines, handle here*/}
                 {selectedOption === 'exercises' && (

--- a/frontend-ui/src/app/routines/[id]/page.jsx
+++ b/frontend-ui/src/app/routines/[id]/page.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { GetToken } from '@/components/AWS/GetToken';
-import WorkoutList from '@/components/routine/WorkoutList'; 
+import WorkoutList from '@/components/routine/workoutList'; 
 
 const RoutineDetails = () => {
     const API_URL = process.env.NEXT_PUBLIC_API_URL;

--- a/frontend-ui/src/app/routines/[id]/page.jsx
+++ b/frontend-ui/src/app/routines/[id]/page.jsx
@@ -1,10 +1,9 @@
-"use client";
-// Import necessary modules and components
-import { useState, useEffect } from 'react';
+"use client"
+import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { GetToken } from '@/components/AWS/GetToken';
-import WorkoutList from '@/components/browse/WorkoutList'; // Update the path as per your project structure
+import WorkoutList from '@/components/routine/WorkoutList'; 
 
 const RoutineDetails = () => {
     const API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -14,6 +13,9 @@ const RoutineDetails = () => {
     const [showEditButton, setShowEditButton] = useState(false);
     const { user } = useAuthenticator((context) => [context.user]);
     const router = useRouter();
+    const [currentWorkoutIndex, setCurrentWorkoutIndex] = useState(0);
+    const [completedWorkouts, setCompletedWorkouts] = useState([]);
+    const [routineHistoryId, setRoutineHistoryId] = useState('');
 
     useEffect(() => {
         const fetchData = async () => {
@@ -29,7 +31,7 @@ const RoutineDetails = () => {
                     }
                     const data = await res.json();
                     setRoutineName(data.routineName);
-
+                    
                     // Fetch detailed information for each workout in the routine
                     const workoutDetailsPromises = data.workoutIds.map(async (workoutId) => {
                         const res = await fetch(`${API_URL}/workouts/${workoutId}`, {
@@ -40,10 +42,30 @@ const RoutineDetails = () => {
                         }
                         return await res.json();
                     });
-
+                    
                     const detailedWorkouts = await Promise.all(workoutDetailsPromises);
                     setWorkoutDetails(detailedWorkouts);
-
+                    console.log(detailedWorkouts);
+    
+                    // TODO: Fetch routine history to get completed workouts
+                    const historyRes = await fetch(`${API_URL}/routine/start/${currentUser}/${data.routineId}`, {
+                         headers: { 'Authorization': `Bearer ${authToken}` }
+                    });
+                    if (!historyRes.ok) {
+                        throw new Error(`Failed to fetch routine history for id: ${id} and user: ${currentUser}`);
+                    }
+                    const historyData = await historyRes.json();
+                    console.log(historyData);
+                    
+                    const completedWorkouts = historyData.completed || [];
+                    setCompletedWorkouts(completedWorkouts);
+                    setRoutineHistoryId(historyData.routineHistoryId);
+    
+                    // Determine the current workout index
+                    const nextWorkoutIndex = data.workoutIds.findIndex(workoutId => !completedWorkouts.includes(workoutId));
+                    console.log(nextWorkoutIndex);
+                    setCurrentWorkoutIndex(nextWorkoutIndex !== -1 ? nextWorkoutIndex : 0);
+    
                     // Check if the current user is allowed to edit
                     if (data.userId === currentUser) {
                         setShowEditButton(true);
@@ -53,9 +75,62 @@ const RoutineDetails = () => {
                 }
             }
         };
-
+    
         fetchData();
     }, [id, user]);
+
+    //for updating routine history to keep track of current workout
+    useEffect(() => {
+        const updateRoutineHistory = async () => {
+            try {
+                const authToken = await GetToken();
+                const res = await fetch(`${API_URL}/routine/start/${routineHistoryId}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Authorization': `Bearer ${authToken}`,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(completedWorkouts)
+                });
+                if (!res.ok) {
+                    throw new Error(`Failed to update routine history for id: ${routineHistoryId}`);
+                }
+            } catch (error) {
+                console.error(error);
+            }
+        };
+    
+        // Call the API to update the routine history whenever completedWorkouts changes
+        if (completedWorkouts.length > 0 || currentWorkoutIndex === 0) {
+            updateRoutineHistory();
+        }
+    }, [completedWorkouts]);
+
+    const handleStartWorkout = () => {
+        if (workoutDetails.length === 0) return;
+    
+        const currentWorkout = workoutDetails[currentWorkoutIndex];
+    
+        // Update the completed workouts state
+        const newCompletedWorkouts = [...completedWorkouts, currentWorkout.workoutId];
+        setCompletedWorkouts(newCompletedWorkouts);
+        console.log(newCompletedWorkouts);
+    
+        // Determine the new current workout index
+        let newIndex = currentWorkoutIndex + 1;
+        if (newIndex >= workoutDetails.length) {
+            newIndex = 0;
+            console.log("All workouts completed");
+            setCompletedWorkouts([]); // Reset completed workouts
+        }
+    
+        // Update the current workout index state
+        setCurrentWorkoutIndex(newIndex);
+    
+        //TODO: reroute to start workout page and pass id
+    };
+    
+
 
     const handleEditClick = () => {
         router.push(`/routines/edit/${id}`);
@@ -74,7 +149,12 @@ const RoutineDetails = () => {
         <div className="container mx-auto px-4">
             <h1 className="text-2xl font-bold text-center mt-5">{routineName}</h1>
             <div className="mt-8">
-                <WorkoutList workouts={workoutDetails} handlePanelClick={handlePanelClick} />
+                <WorkoutList
+                    workouts={workoutDetails}
+                    handlePanelClick={handlePanelClick}
+                    currentWorkoutIndex={currentWorkoutIndex}
+                    completedWorkouts={completedWorkouts}
+                />
                 <div className="flex justify-center mt-8 space-x-4">
                     {showEditButton && (
                         <button
@@ -84,6 +164,12 @@ const RoutineDetails = () => {
                             Edit Routine
                         </button>
                     )}
+                    <button 
+                        className="px-4 py-2 text-white bg-blue-500 rounded" 
+                        onClick={handleStartWorkout}
+                    >
+                        Start Workout
+                    </button>
                     <button
                         className="px-4 py-2 text-white bg-gray-500 rounded"
                         onClick={handleBackClick}

--- a/frontend-ui/src/app/routines/[id]/page.jsx
+++ b/frontend-ui/src/app/routines/[id]/page.jsx
@@ -83,17 +83,21 @@ const RoutineDetails = () => {
     useEffect(() => {
         const updateRoutineHistory = async () => {
             try {
-                const authToken = await GetToken();
-                const res = await fetch(`${API_URL}/routine/start/${routineHistoryId}`, {
-                    method: 'PUT',
-                    headers: {
-                        'Authorization': `Bearer ${authToken}`,
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(completedWorkouts)
-                });
-                if (!res.ok) {
-                    throw new Error(`Failed to update routine history for id: ${routineHistoryId}`);
+                //ensure not being called before history id is ready
+                if (routineHistoryId){
+                    const authToken = await GetToken();
+                    const res = await fetch(`${API_URL}/routine/start/${routineHistoryId}`, {
+                        method: 'PUT',
+                        headers: {
+                            'Authorization': `Bearer ${authToken}`,
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(completedWorkouts)
+                    });
+                    if (!res.ok) {
+                        throw new Error(`Failed to update routine history for id: ${routineHistoryId}`);
+                    }
+
                 }
             } catch (error) {
                 console.error(error);
@@ -128,6 +132,8 @@ const RoutineDetails = () => {
         setCurrentWorkoutIndex(newIndex);
     
         //TODO: reroute to start workout page and pass id
+        console.log(currentWorkout);
+        router.push(`/workouts/start?id=${currentWorkout.workoutId.toString()}`);
     };
     
 

--- a/frontend-ui/src/components/routine/workoutList.jsx
+++ b/frontend-ui/src/components/routine/workoutList.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { CheckIcon } from '@heroicons/react/24/solid';
+
+const WorkoutList = ({ workouts, handlePanelClick, currentWorkoutIndex, completedWorkouts }) => {
+  return (
+    <div className="mt-4 space-y-4">
+      {workouts.map((workout, index) => (
+        <div key={workout.workoutId}>
+          <div
+            className={`flex items-center p-4 border rounded-lg shadow-md cursor-pointer hover:bg-gray-100 ${index === currentWorkoutIndex ? 'bg-blue-100' : ''}`}
+            onClick={() => handlePanelClick(workout)}
+          >
+            <div className="flex-shrink-0 w-16 h-16 relative">
+              <img
+                src={`/category/${workout.category}.jpg`} // Update the path and extension as needed
+                alt={workout.category}
+                className="w-full h-full object-cover rounded-lg"
+              />
+              {index === currentWorkoutIndex && (
+                <div className="absolute top-0 left-0 bg-blue-500 text-white text-xs font-semibold px-2 py-1 rounded-bl-lg">
+                  Current
+                </div>
+              )}
+            </div>
+            <div className="ml-4 flex-1">
+              <h3 className="text-lg font-semibold">{workout.name}</h3>
+              <p className="text-gray-600">{workout.category}</p>
+            </div>
+            {completedWorkouts.includes(workout.workoutId) && (
+              <CheckIcon className="w-6 h-6 text-green-500 ml-auto" />
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default WorkoutList;


### PR DESCRIPTION
# What has been done?

## Summary Front End

- added ability to start a routine and track which workouts have been completed
- updated currently exercising page to allow for skipping an exercise
   - this change included ensuring exercises skipped or if all sets were removed are not saved in DB  


### Detailed info on Front End
- updated the browse specific routine page to allow for starting a routine/workout
    - page displays info on which workouts in the routine have been completed and which is the current workout
    - clicking on start routine will redirect to the start workout page for the current workout in the routine to be done
    - based on the database object and which workouts are contained within it, that will determine which workouts have been completed


## Summary Back End
- created route to handle managing state of the routine
- created corresponding service function to handle database access
- created routine history schema


### Detailed info on Back End

- backend will get from the database the object for a specific user and routine and return that to user
   -  on first time a user clicks on a routine, a new object will be automatically created
   - routine history schema defines how a routines current and completed workouts will be tracked
- a post route to update the routine history once a workout is started also set up
   - if all workouts have been completed, routine history will be reset to start at beginning again  


# Usage
- from the browse page select a routine you want to start
- one started you will be redirected to the start workout page
- skip or complete the workout
- next time you view the routine, you should see indication that the workout is completed and the current workout indicator will be on the next workout

- for workout updates, removing all sets will act similar to skip button however the summary will show the exercises
- if all exercises are skipped, workout summary will just display date and time
