### PR TITLE
Mara/progress

### DIFF
--- a/frontend-ui/src/components/progress/ProgressGraph.jsx
+++ b/frontend-ui/src/components/progress/ProgressGraph.jsx
@@ -1,4 +1,4 @@
-import { Label, Legend, Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
+import { Label, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 // component to display Progress graph
 export default function ProgressGraph( {data} ) {
@@ -12,7 +12,7 @@ export default function ProgressGraph( {data} ) {
         dataKey="date"
         domain={['auto', 'auto']}
         tickFormatter={(unixTime) => {
-          return new Date(unixTime).toISOString().split('T')[0];
+          return new Date(unixTime).toDateString().slice(4);
         }}>
           <Label value={"Date Completed"} offset={0} position="bottom" />
         </XAxis>
@@ -20,6 +20,7 @@ export default function ProgressGraph( {data} ) {
           <Label value={"Average Weight"} angle={-90}/>
         </YAxis>
         <Legend height={60} layout="vertical" verticalAlign="top"/>
+        <Tooltip labelFormatter={value => {return `${new Date(value).toDateString().slice(4)}`}}/>
         {data.map((lineData, i) => (
           <Line
             name={lineData[0].exerciseName}

--- a/frontend-ui/src/components/progress/WeightGraph.jsx
+++ b/frontend-ui/src/components/progress/WeightGraph.jsx
@@ -2,6 +2,13 @@ import { Label, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } fr
 
 // component to display weight graph
 export default function WeightGraph( {data} ) {
+  // find minimum weight entry value
+  var minWeight = 9999;
+  for (const entry of data) {
+    if (entry.weight < minWeight) {
+      minWeight = entry.weight;
+    }
+  }
   return (
     <ResponsiveContainer width='95%' height='50%'>
       <LineChart margin={{ top: 30, right: 0, left: 0, bottom: 30}}>
@@ -10,14 +17,14 @@ export default function WeightGraph( {data} ) {
         dataKey="timeStamp"
         domain={['auto', 'auto']}
         tickFormatter={(unixTime) => {
-          return new Date(unixTime).toISOString().split('T')[0];
+          return new Date(unixTime).toDateString().slice(4);
         }}>
           <Label value={"Date Entered"} offset={0} position="bottom" />
         </XAxis>
-        <YAxis dataKey="weight">
+        <YAxis dataKey="weight" domain={[(minWeight - 5), 'auto']}>
           <Label value={"Body Weight (kgs)"} angle={-90}/>
         </YAxis>
-        <Tooltip />
+        <Tooltip labelFormatter={value => {return `${new Date(value).toDateString().slice(4)}`}}/>
         <Line
           data={data}
           dataKey="weight"


### PR DESCRIPTION
Quick fix to adjust weight graph's y-axis scale, and the tooltips date displays for both graphs on progress page.